### PR TITLE
Implement applying to staged files

### DIFF
--- a/src/ai/request.rs
+++ b/src/ai/request.rs
@@ -69,6 +69,14 @@ impl Request {
             prompt.push('\n');
         }
 
+        if cfg.gai.only_staged {
+            prompt.push_str(
+                "ONLY GENERATE COMMITS FOR THE STAGED FILES",
+            );
+
+            prompt.push('\n');
+        }
+
         prompt.push_str(&rules);
         prompt.push('\n');
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,10 @@ use crate::{ai::provider::Provider, config::Config};
 #[command(about, long_about = None)]
 #[command(override_usage = "\n  gai [OPTIONS] [COMMAND]")]
 pub struct Cli {
+    /// Only generate for staged files/hunks
+    #[arg(long)]
+    pub only_staged: bool,
+
     /// include untracked files
     #[arg(short = 'u', long)]
     pub include_untracked: bool,
@@ -116,7 +120,7 @@ pub enum Commands {
         auto_request: bool,
     },
 
-    /// Create commits
+    /// Create commits from the diffs in the working tree
     Commit {
         /// Skips the confirmation prompt and applies
         /// the commits
@@ -247,6 +251,10 @@ impl Cli {
 
         if let Some(ref hint) = self.hint {
             config.ai.hint = Some(hint.to_owned());
+        }
+
+        if self.only_staged {
+            config.gai.only_staged = true;
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,7 @@ impl Config {
 /// gai git specific settings
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct GaiConfig {
+    pub only_staged: bool,
     /// should we apply as hunks?
     pub stage_hunks: bool,
     pub commit_config: CommitConfig,

--- a/src/git/diffs.rs
+++ b/src/git/diffs.rs
@@ -19,8 +19,15 @@ impl GaiGit {
         let repo = &self.repo;
 
         let head = repo.head()?.peel_to_tree()?;
-        let diff =
-            repo.diff_tree_to_workdir(Some(&head), Some(&mut opts))?;
+        let diff = if self.only_staged {
+            repo.diff_tree_to_index(
+                Some(&head),
+                None,
+                Some(&mut opts),
+            )?
+        } else {
+            repo.diff_tree_to_workdir(Some(&head), Some(&mut opts))?
+        };
 
         let mut gai_files: Vec<GaiFile> = Vec::new();
 
@@ -53,6 +60,10 @@ impl GaiGit {
 
             true
         })?;
+
+        if self.only_staged {
+            return Ok(());
+        }
 
         self.files = gai_files;
 

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -12,6 +12,7 @@ pub struct GaiGit {
 
     pub status: GaiStatus,
 
+    pub only_staged: bool,
     pub stage_hunks: bool,
     pub capitalize_prefix: bool,
     pub include_scope: bool,
@@ -70,6 +71,7 @@ impl GaiGit {
     /// for now, im not gonna handle those and we
     /// just straight up panic if we failed to open
     pub fn new(
+        only_staged: bool,
         stage_hunks: bool,
         capitalize_prefix: bool,
         include_scope: bool,
@@ -81,6 +83,7 @@ impl GaiGit {
             repo,
             files: Vec::new(),
             status,
+            only_staged,
             stage_hunks,
             capitalize_prefix,
             include_scope,

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ async fn main() -> Result<()> {
         }
         _ => {
             let mut gai = GaiGit::new(
+                cfg.gai.only_staged,
                 cfg.gai.stage_hunks,
                 cfg.gai.commit_config.capitalize_prefix,
                 cfg.gai.commit_config.include_scope,


### PR DESCRIPTION
`gai` can already apply commits to already staged files. It also does a `clear()` which resets the staging area and points it back to HEAD, the LLM can respond with the files to re-add, which does so. The `create_diffs` also already reads the changes and inserts it into the Request. Realistically, I don't think there's anything else to do here. I think it's fine that we clear the index, and re-add the necessary files.

However, say the user only wants to generate a commit message specifically for what's already staged, then maybe we can implement a override flag and run a separate flow.

Closes #17 