### PR TITLE
feat: implement reword command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -83,6 +83,9 @@ pub enum Commands {
 
     /// Generate a rebase plan for a branch
     Rebase(RebaseArgs),
+
+    /// Reword or amend a commit message
+    Reword(RewordArgs),
 }
 
 #[derive(Debug, Subcommand)]
@@ -200,4 +203,23 @@ pub struct RebaseArgs {
         help = "Generate a Rebase plan using RebaseOperations, in place of entire commits.\nThis is synonymous with `git rebase --edit-todo` during an interactive rebase."
     )]
     pub plan: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct RewordArgs {
+    /// Specify the specific commit hash to amend
+    #[arg(short = 'c', long)]
+    pub commit: Option<String>,
+
+    /// Specify the amount of last commit messages to amend
+    #[arg(short = 'l', long)]
+    pub last: Option<usize>,
+
+    /// Specify the starting range for the commits you want to amend from.
+    #[arg(long)]
+    pub from: Option<String>,
+
+    /// Specify ending range of the commits to amend.
+    #[arg(long)]
+    pub to: Option<String>,
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3,6 +3,7 @@ pub mod commit;
 pub mod find;
 pub mod log;
 pub mod rebase;
+pub mod reword;
 pub mod status;
 
 pub use rebase::run;

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -113,8 +113,6 @@ pub fn run(
         log_strs.push(item);
     }
 
-    let log_strs = log_strs.join("\n");
-
     let schema_settings = if matches!(
         state
             .settings

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -2,8 +2,11 @@ use crate::{
     args::{GlobalArgs, RewordArgs},
     git::{
         GitRepo,
-        log::{get_log, get_logs},
-        rebase::trailing_commits,
+        checkout::force_checkout_head,
+        log::{Logs, get_log, get_logs},
+        rebase::{
+            cherry_pick_commits, cherry_pick_reword, trailing_commits,
+        },
         status::is_workdir_clean,
         utils::get_head_repo,
     },
@@ -196,10 +199,10 @@ pub fn run(
         if selected == 0 {
             if apply(
                 &state.git,
+                &logs,
                 &commit_messages,
                 &trailing_commits,
-                &original_head,
-            ) {
+            )? {
                 continue;
             }
         } else if selected == 1 {
@@ -217,9 +220,33 @@ pub fn run(
 
 fn apply(
     git: &GitRepo,
-    commit_messages: &[String],
+    logs: &Logs,
+    new_commit_messages: &[String],
     trailing_commits: &[String],
-    original_head: &str,
-) -> bool {
-    false
+) -> anyhow::Result<bool> {
+    for (idx, log) in logs
+        .git_logs
+        .iter()
+        .enumerate()
+    {
+        let commit = log
+            .commit_hash
+            .to_owned();
+
+        if let Some(message) = new_commit_messages.get(idx) {
+            cherry_pick_reword(&git.repo, &commit, &message)?;
+        } else {
+            return Err(anyhow::anyhow!("bad index"));
+        }
+    }
+
+    if !trailing_commits.is_empty() {
+        cherry_pick_commits(&git.repo, trailing_commits)?;
+    }
+    // readd the trailing commits if any
+
+    // then sync it
+    force_checkout_head(&git.repo)?;
+
+    Ok(false)
 }

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -4,7 +4,7 @@ use crate::{
         GitRepo,
         checkout::force_checkout_head,
         commit::find_parent_commit,
-        log::{Logs, get_log, get_logs},
+        log::{Logs, get_logs},
         rebase::{
             cherry_pick_commits, cherry_pick_reword, trailing_commits,
         },
@@ -247,7 +247,7 @@ fn apply(
     // reset to -> parent of from commit
     let oldest = &logs.git_logs[0].commit_hash;
 
-    let parent = find_parent_commit(&git.repo, &oldest)?;
+    let parent = find_parent_commit(&git.repo, oldest)?;
 
     reset_repo_hard(&git.repo, &parent.to_string())?;
 
@@ -261,7 +261,7 @@ fn apply(
             .to_owned();
 
         if let Some(message) = new_commit_messages.get(idx) {
-            cherry_pick_reword(&git.repo, &commit, &message)?;
+            cherry_pick_reword(&git.repo, &commit, message)?;
         } else {
             return Err(anyhow::anyhow!("bad index"));
         }

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -1,8 +1,48 @@
-use crate::args::{GlobalArgs, RewordArgs};
+use crate::{
+    args::{GlobalArgs, RewordArgs},
+    git::{
+        log::{get_log, get_logs},
+        status::is_workdir_clean,
+    },
+    providers::provider::ProviderKind,
+    schema::SchemaSettings,
+    state::State,
+};
 
 pub fn run(
     args: &RewordArgs,
     global: &GlobalArgs,
 ) -> anyhow::Result<()> {
+    let state = State::new(
+        global
+            .config
+            .as_deref(),
+        global,
+    )?;
+
+    if !is_workdir_clean(&state.git.repo)? {
+        return Err(anyhow::anyhow!(
+            "Workdir is NOT clean, please save your changes"
+        ));
+    }
+
+    // single commit
+    if let Some(ref commit_hash) = args.commit {
+        let log = get_log(&state.git, &commit_hash)?;
+    }
+
+    let schema_settings = if matches!(
+        state
+            .settings
+            .provider,
+        ProviderKind::OpenAI
+    ) {
+        SchemaSettings::default()
+            .additional_properties(false)
+            .allow_min_max_ints(true)
+    } else {
+        SchemaSettings::default().allow_min_max_ints(true)
+    };
+
     Ok(())
 }

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -1,11 +1,21 @@
 use crate::{
     args::{GlobalArgs, RewordArgs},
     git::{
+        GitRepo,
         log::{get_log, get_logs},
+        rebase::trailing_commits,
         status::is_workdir_clean,
+        utils::get_head_repo,
     },
-    providers::provider::ProviderKind,
-    schema::SchemaSettings,
+    print::{
+        commits::print_response_commits, loading, print_retry_prompt,
+    },
+    providers::{extract_from_provider, provider::ProviderKind},
+    requests::reword::create_reword_request,
+    responses::reword::{
+        parse_to_reword_commit_schema, process_reword_commit_message,
+    },
+    schema::{SchemaSettings, reword::create_reword_schema},
     state::State,
 };
 
@@ -26,9 +36,76 @@ pub fn run(
         ));
     }
 
-    // single commit
-    if let Some(ref commit_hash) = args.commit {
-        let log = get_log(&state.git, &commit_hash)?;
+    let original_head = get_head_repo(&state.git.repo)?.to_string();
+
+    // mimicing the rebase flow, its pretty similar, the only major difference
+    // is that we dont gen a plan, but only reword selected commits
+    let (logs, trailing_commits) = if let Some(ref hash) = args.commit
+    {
+        let logs = get_logs(
+            &state.git,
+            true,
+            false,
+            0,
+            true,
+            Some(hash),
+            Some(hash),
+            None,
+        )?;
+
+        let trails = trailing_commits(&state.git.repo, hash)?;
+
+        (logs, trails)
+    } else if let Some(last_n) = args.last {
+        let logs = get_logs(
+            &state.git, true, false, last_n, true, None, None, None,
+        )?;
+
+        // return an empty vec for now
+        // want to just leave trails empty
+        // instead of returning an
+        // option to unwrap
+        (logs, Vec::new())
+    } else if args.from.is_some() {
+        let logs = get_logs(
+            &state.git,
+            true,
+            false,
+            0,
+            true,
+            args.from.as_deref(),
+            args.to.as_deref(),
+            None,
+        )?;
+
+        let to_hash = args
+            .to
+            .to_owned()
+            .unwrap_or(get_head_repo(&state.git.repo)?.to_string());
+
+        let trails = trailing_commits(&state.git.repo, &to_hash)?;
+
+        (logs, trails)
+    } else {
+        // do interactive
+        todo!()
+    };
+
+    let mut log_strs = Vec::new();
+
+    for (idx, log) in logs
+        .git_logs
+        .iter()
+        .enumerate()
+    {
+        let files: String = log.files.join(",");
+
+        let item = format!(
+            "CommitID:[{}]\nCommitMessage:{}\nFiles:{}",
+            idx, log.raw, files
+        );
+
+        log_strs.push(item);
     }
 
     let schema_settings = if matches!(
@@ -44,5 +121,105 @@ pub fn run(
         SchemaSettings::default().allow_min_max_ints(true)
     };
 
+    let schema =
+        create_reword_schema(schema_settings, &state.settings)?;
+
+    // diffs here?
+    let request = create_reword_request(
+        &state.settings,
+        &state.git,
+        &state
+            .diffs
+            .to_string(),
+    );
+
+    loop {
+        let loading = loading::Loading::new(
+            "Generating New Commit Messages",
+            global.compact,
+        )?;
+
+        loading.start();
+
+        let response: serde_json::Value = match extract_from_provider(
+            &state
+                .settings
+                .provider,
+            request.to_owned(),
+            schema.to_owned(),
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = format!(
+                    "Gai received an error from the provider:\n{:#}\nRetry?",
+                    e
+                );
+
+                loading.stop();
+
+                if print_retry_prompt(Some(&msg))? {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        };
+
+        let raw_commits = parse_to_reword_commit_schema(response)?;
+
+        loading.stop();
+
+        println!(
+            "Done! Received {} Commit{}",
+            raw_commits.len(),
+            if raw_commits.len() == 1 { "" } else { "s" }
+        );
+
+        let selected = if let Some(s) = print_response_commits(
+            &raw_commits,
+            global.compact,
+            false,
+            false,
+        )? {
+            s
+        } else {
+            return Ok(());
+        };
+
+        let commit_messages: Vec<String> = raw_commits
+            .into_iter()
+            .map(|c| {
+                process_reword_commit_message(c, &state.settings)
+            })
+            .collect();
+
+        if selected == 0 {
+            if apply(
+                &state.git,
+                &commit_messages,
+                &trailing_commits,
+                &original_head,
+            ) {
+                continue;
+            }
+        } else if selected == 1 {
+            println!("Regenerating");
+            continue;
+        } else if selected == 2 {
+            println!("Exiting");
+        }
+
+        break;
+    }
+
     Ok(())
+}
+
+fn apply(
+    git: &GitRepo,
+    commit_messages: &[String],
+    trailing_commits: &[String],
+    original_head: &str,
+) -> bool {
+    false
 }

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -3,10 +3,12 @@ use crate::{
     git::{
         GitRepo,
         checkout::force_checkout_head,
+        commit::find_parent_commit,
         log::{Logs, get_log, get_logs},
         rebase::{
             cherry_pick_commits, cherry_pick_reword, trailing_commits,
         },
+        reset::reset_repo_hard,
         status::is_workdir_clean,
         utils::get_head_repo,
     },
@@ -111,6 +113,8 @@ pub fn run(
         log_strs.push(item);
     }
 
+    let log_strs = log_strs.join("\n");
+
     let schema_settings = if matches!(
         state
             .settings
@@ -127,14 +131,8 @@ pub fn run(
     let schema =
         create_reword_schema(schema_settings, &state.settings)?;
 
-    // diffs here?
-    let request = create_reword_request(
-        &state.settings,
-        &state.git,
-        &state
-            .diffs
-            .to_string(),
-    );
+    let request =
+        create_reword_request(&state.settings, &state.git, &log_strs);
 
     loop {
         let loading = loading::Loading::new(
@@ -197,13 +195,26 @@ pub fn run(
             .collect();
 
         if selected == 0 {
-            if apply(
+            match apply(
                 &state.git,
                 &logs,
                 &commit_messages,
                 &trailing_commits,
-            )? {
-                continue;
+            ) {
+                // my god
+                Ok(retry) => {
+                    if retry {
+                        reset_repo_hard(
+                            &state.git.repo,
+                            &original_head,
+                        )?;
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    reset_repo_hard(&state.git.repo, &original_head)?;
+                    return Err(e);
+                }
             }
         } else if selected == 1 {
             println!("Regenerating");
@@ -224,6 +235,16 @@ fn apply(
     new_commit_messages: &[String],
     trailing_commits: &[String],
 ) -> anyhow::Result<bool> {
+    // for the range and everything to work
+    // when applying, gonna need to quickly
+    // mimic the reset flow from rebase
+    // reset to -> parent of from commit
+    let oldest = &logs.git_logs[0].commit_hash;
+
+    let parent = find_parent_commit(&git.repo, &oldest)?;
+
+    reset_repo_hard(&git.repo, &parent.to_string())?;
+
     for (idx, log) in logs
         .git_logs
         .iter()

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -47,13 +47,17 @@ pub fn run(
     // is that we dont gen a plan, but only reword selected commits
     let (logs, trailing_commits) = if let Some(ref hash) = args.commit
     {
+        // we need the parent commit, to get the root since
+        // from is exclusive
+        let parent = find_parent_commit(&state.git.repo, hash)?;
+
         let logs = get_logs(
             &state.git,
             true,
             false,
             0,
             true,
-            Some(hash),
+            Some(&parent.to_string()),
             Some(hash),
             None,
         )?;
@@ -62,9 +66,13 @@ pub fn run(
 
         (logs, trails)
     } else if let Some(last_n) = args.last {
-        let logs = get_logs(
-            &state.git, true, false, last_n, true, None, None, None,
+        let mut logs = get_logs(
+            &state.git, true, false, last_n, false, None, None, None,
         )?;
+
+        // if logs are reversed
+        logs.git_logs
+            .reverse();
 
         // return an empty vec for now
         // want to just leave trails empty

--- a/src/cmd/reword.rs
+++ b/src/cmd/reword.rs
@@ -1,0 +1,8 @@
+use crate::args::{GlobalArgs, RewordArgs};
+
+pub fn run(
+    args: &RewordArgs,
+    global: &GlobalArgs,
+) -> anyhow::Result<()> {
+    Ok(())
+}

--- a/src/git/log.rs
+++ b/src/git/log.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use git2::Oid;
+use git2::{Oid, Repository};
 use std::fmt;
 
 use super::{
@@ -208,6 +208,62 @@ pub fn get_short_hash(git_log: &GitLog) -> String {
             .len(),
     )]
         .to_string()
+}
+
+// gets a single commit log from
+// a specified commit hash string
+// will always populate files, and
+// file diff
+pub fn get_log(
+    git_repo: &GitRepo,
+    commit: &str,
+) -> anyhow::Result<GitLog> {
+    let oid = Oid::from_str(commit)?;
+
+    let repo = &git_repo.repo;
+
+    let commit = repo.find_commit(oid)?;
+
+    let mut log: GitLog = commit
+        .message_bytes()
+        .into();
+
+    let author = commit.author();
+
+    log.author = author
+        .name()
+        .unwrap_or("unknown author")
+        .to_string();
+
+    log.commit_hash = oid.to_string();
+    log.date = DateTime::from_timestamp(
+        author
+            .when()
+            .seconds(),
+        0,
+    )
+    .map(|dt| {
+        dt.format("%m/%d/%Y %H:%M:%S")
+            .to_string()
+    })
+    .unwrap_or_default();
+
+    log.files = get_commit_files(repo, oid, None)?
+        .iter()
+        .map(|f| f.path.to_string())
+        .collect();
+
+    for file in &log.files {
+        let raw = get_commit_diff(repo, oid)?;
+        let file_diff =
+            raw_diff_to_file_diff(&raw, file, &git_repo.workdir)?;
+
+        log.diffs
+            .files
+            .push(file_diff);
+    }
+
+    Ok(log)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/git/log.rs
+++ b/src/git/log.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use git2::{Oid, Repository};
+use git2::Oid;
 use std::fmt;
 
 use super::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ pub mod state;
 pub mod utils;
 
 use crate::args::Commands::{
-    Auth, Commit, Find, Log, Rebase, Status,
+    Auth, Commit, Find, Log, Rebase, Reword, Status,
 };
 
 fn main() -> anyhow::Result<()> {
@@ -28,6 +28,7 @@ fn main() -> anyhow::Result<()> {
         Log(a) => cmd::log::run(a, &args.global)?,
         Find(a) => cmd::find::run(a, &args.global)?,
         Rebase(a) => cmd::rebase::run(a, &args.global)?,
+        Reword(a) => cmd::reword::run(a, &args.global)?,
     };
 
     Ok(())

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -3,5 +3,6 @@ pub mod commit;
 pub mod find;
 pub mod rebase;
 pub mod rebase_plan;
+pub mod reword;
 
 pub use builder::{ContentPart, Request};

--- a/src/requests/reword.rs
+++ b/src/requests/reword.rs
@@ -1,7 +1,6 @@
 use crate::{
     git::{
-        GitRepo, StagingStrategy, StatusStrategy, log::get_logs,
-        status::get_status,
+        GitRepo, StatusStrategy, log::get_logs, status::get_status,
     },
     settings::{PromptRules, Settings},
     utils::consts::*,
@@ -12,20 +11,25 @@ use super::Request;
 pub fn create_reword_request(
     settings: &Settings,
     repo: &GitRepo,
-    logs: &str,
+    logs: &[String],
 ) -> Request {
-    let prompt = build_prompt(repo, settings);
+    let prompt = build_prompt(repo, settings, logs.len());
 
-    Request::new(&prompt).insert_content(logs)
+    Request::new(&prompt).insert_contents(logs)
 }
 
 fn build_prompt(
     repo: &GitRepo,
     cfg: &Settings,
+    log_count: usize,
 ) -> String {
     let mut prompt = String::new();
 
     let rules = build_rules(&cfg.rules);
+
+    prompt.push_str(
+        format!("Generate {} commit messages", log_count).as_str(),
+    );
 
     if let Some(sys_prompt) = &cfg
         .prompt
@@ -120,6 +124,7 @@ fn build_prompt(
 
     prompt
 }
+
 fn build_rules(cfg: &PromptRules) -> String {
     let mut rules = String::new();
 

--- a/src/requests/reword.rs
+++ b/src/requests/reword.rs
@@ -1,0 +1,172 @@
+use crate::{
+    git::{
+        GitRepo, StagingStrategy, StatusStrategy, log::get_logs,
+        status::get_status,
+    },
+    settings::{PromptRules, Settings},
+    utils::consts::*,
+};
+
+use super::Request;
+
+pub fn create_reword_request(
+    settings: &Settings,
+    repo: &GitRepo,
+    logs: &str,
+) -> Request {
+    let prompt = build_prompt(repo, settings);
+
+    Request::new(&prompt).insert_content(logs)
+}
+
+fn build_prompt(
+    repo: &GitRepo,
+    cfg: &Settings,
+) -> String {
+    let mut prompt = String::new();
+
+    let rules = build_rules(&cfg.rules);
+
+    if let Some(sys_prompt) = &cfg
+        .prompt
+        .system_prompt
+    {
+        prompt.push_str(sys_prompt);
+    } else {
+        prompt.push_str(DEFAULT_SYS_PROMPT);
+    };
+
+    prompt.push('\n');
+
+    if let Some(hint) = &cfg.prompt.hint {
+        prompt.push_str(
+            format!("USE THIS IS A HINT FOR YOUR COMMITS: {}", hint)
+                .as_str(),
+        );
+        prompt.push('\n');
+    }
+
+    prompt.push_str(&rules);
+    prompt.push('\n');
+
+    if let Some(commit_conv) = &cfg
+        .prompt
+        .commit_convention
+    {
+        prompt.push_str(commit_conv);
+    }
+
+    if cfg
+        .context
+        .include_convention
+    {
+        prompt.push_str(COMMIT_CONVENTION);
+    }
+
+    prompt.push('\n');
+
+    if cfg
+        .context
+        .include_file_tree
+    {
+        prompt.push_str("Current File Tree: \n");
+        //prompt.push_str(&git.get_repo_tree());
+        prompt.push('\n');
+    }
+
+    if cfg
+        .context
+        .include_git_status
+    {
+        prompt.push_str("Current Git Status: \n");
+        // todo impl separation when fmt::Display
+        let staged =
+            get_status(&repo.repo, &StatusStrategy::Stage).unwrap();
+        let working_dir =
+            get_status(&repo.repo, &StatusStrategy::WorkingDir)
+                .unwrap();
+
+        prompt.push_str(&format!("Staged\n{}", staged));
+        prompt.push_str(&format!("WorkingDir\n{}", working_dir));
+    }
+
+    if cfg
+        .context
+        .include_log
+    {
+        let gai_logs = get_logs(
+            repo,
+            true,
+            false,
+            cfg.context
+                .log_amount as usize,
+            false,
+            None,
+            None,
+            None,
+        )
+        .unwrap_or_default();
+
+        let log_str = format!(
+            "{} Recent Git Logs:\n{}\n",
+            gai_logs
+                .git_logs
+                .len(),
+            gai_logs
+        );
+
+        prompt.push_str(&log_str);
+    }
+
+    prompt
+}
+fn build_rules(cfg: &PromptRules) -> String {
+    let mut rules = String::new();
+
+    if cfg.group_related_files {
+        rules.push_str(RULE_GROUP_FILES);
+    }
+
+    if cfg.separate_by_purpose {
+        rules.push_str(RULE_SEPARATE_BY_PURPOSE);
+    }
+
+    rules.push_str(RULE_COMMIT_MESSAGE_HEADER);
+    rules.push_str(RULE_PREFIX);
+
+    let scope_rule =
+        match (cfg.allow_empty_scope, cfg.extension_in_scope) {
+            (true, true) => RULE_SCOPE_ALLOW_EMPTY_WITH_EXTENSION,
+            (true, false) => RULE_SCOPE_ALLOW_EMPTY_NO_EXTENSION,
+            (false, true) => RULE_SCOPE_REQUIRED_WITH_EXTENSION,
+            (false, false) => RULE_SCOPE_REQUIRED_NO_EXTENSION,
+        };
+    rules.push_str(scope_rule);
+
+    rules.push_str(RULE_BREAKING);
+
+    rules.push_str(RULE_HEADER_BASE);
+    rules.push_str(&format!(
+        "    - CRITICAL: Maximum length is {} characters\n",
+        cfg.max_header_length
+    ));
+
+    if cfg.allow_body {
+        rules.push_str(RULE_BODY_BASE);
+        rules.push_str(&format!(
+            "    - CRITICAL: Maximum length is {} characters\n",
+            cfg.max_body_length
+        ));
+    } else {
+        rules.push_str("DO NOT CREATE A BODY, LEAVE IT BLANK");
+    }
+
+    if cfg.verbose_descriptions {
+        rules.push_str(RULE_MESSAGE_VERBOSE);
+    } else {
+        rules.push_str(RULE_MESSAGE_CONCISE);
+    }
+
+    rules.push('\n');
+    rules
+}

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -2,3 +2,4 @@ pub mod commit;
 pub mod find;
 pub mod rebase;
 pub mod rebase_plan;
+pub mod reword;

--- a/src/responses/reword.rs
+++ b/src/responses/reword.rs
@@ -67,7 +67,7 @@ pub fn process_reword_commit_message(
     // check is not part of commit settings
     // EXISTENCE SHOULD be handled during
     // schema creation
-    let message = if let Some(body) = raw_commit.body {
+    if let Some(body) = raw_commit.body {
         format!(
             "{}{}{}: {}\n\n{}",
             prefix, scope, breaking, raw_commit.header, body
@@ -77,7 +77,5 @@ pub fn process_reword_commit_message(
             "{}{}{}: {}",
             prefix, scope, breaking, raw_commit.header
         )
-    };
-
-    message
+    }
 }

--- a/src/responses/reword.rs
+++ b/src/responses/reword.rs
@@ -1,0 +1,83 @@
+use crate::{schema::commit::CommitSchema, settings::Settings};
+
+/// extract CommitSchemas from response
+/// should return a List of commit schemas
+/// tho the amount will differ
+/// depending on the StagingStrategy
+/// we can handle as is
+pub fn parse_to_reword_commit_schema(
+    value: serde_json::Value
+) -> anyhow::Result<Vec<CommitSchema>> {
+    let commits: Vec<CommitSchema> = serde_json::from_value(
+        value
+            .get("commits")
+            .ok_or(anyhow::anyhow!(
+                "No commits array in Response json"
+            ))?
+            .to_owned(),
+    )?;
+
+    Ok(commits)
+}
+
+// apply settings to a
+// single commit using
+// CommitSettings
+pub fn process_reword_commit_message(
+    raw_commit: CommitSchema,
+    settings: &Settings,
+) -> String {
+    let commit_settings = &settings.commit;
+    // prefix(scope)breaking: header
+    //
+    // body
+
+    let prefix = if commit_settings.capitalize_prefix {
+        &raw_commit
+            .prefix
+            .to_string()
+    } else {
+        &raw_commit
+            .prefix
+            .to_string()
+            .to_lowercase()
+    };
+
+    let scope = if let Some(scope) = raw_commit.scope
+        && commit_settings.include_scope
+    {
+        format!("({})", scope)
+    } else {
+        String::new()
+    };
+
+    // again, redudant
+    let breaking = if raw_commit
+        .breaking
+        .is_some_and(|b| b)
+        && commit_settings.include_breaking
+    {
+        commit_settings
+            .breaking_symbol
+            .to_string()
+    } else {
+        String::new()
+    };
+
+    // check is not part of commit settings
+    // EXISTENCE SHOULD be handled during
+    // schema creation
+    let message = if let Some(body) = raw_commit.body {
+        format!(
+            "{}{}{}: {}\n\n{}",
+            prefix, scope, breaking, raw_commit.header, body
+        )
+    } else {
+        format!(
+            "{}{}{}: {}",
+            prefix, scope, breaking, raw_commit.header
+        )
+    };
+
+    message
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -3,6 +3,7 @@ pub mod commit;
 pub mod find;
 pub mod rebase;
 pub mod rebase_plan;
+pub mod reword;
 
 pub use builder::{SchemaBuilder, SchemaSettings};
 

--- a/src/schema/reword.rs
+++ b/src/schema/reword.rs
@@ -1,0 +1,41 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::schema::{SchemaBuilder, SchemaSettings};
+
+/// wrapper struct for the reword response
+/// schema to deserialize from
+#[derive(Debug, Deserialize)]
+pub struct RewordResponse {
+    #[serde(default)]
+    pub commit_messages: Vec<CommitMsgSchema>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CommitMsgSchema {}
+
+/// creates a schema for new commit messages
+/// following the proper format
+pub fn create_find_schema(
+    schema_settings: SchemaSettings,
+    max: u32,
+) -> anyhow::Result<Value> {
+    let builder = SchemaBuilder::new()
+        .settings(schema_settings.to_owned())
+        .insert_str(
+            "reasoning",
+            Some("reason why you decided to chose this specific commit"),
+            true,
+        )
+        .insert_int(
+            "commit_id",
+            Some("commit index for the chosen commit"),
+            true,
+            Some(0),
+            Some(max),
+        );
+
+    let schema = builder.build();
+
+    Ok(schema)
+}

--- a/src/schema/reword.rs
+++ b/src/schema/reword.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Debug, Deserialize)]
 pub struct RewordResponse {
     #[serde(default)]
-    pub commit_messages: Vec<CommitSchema>,
+    pub commits: Vec<CommitSchema>,
 }
 
 /// creates a schema for new commit messages
@@ -68,7 +68,17 @@ pub fn create_reword_schema(
         builder.add_str("body", Some("extended description"), true);
     }
 
-    let schema = builder.build();
+    let schema = builder.build_inner();
+
+    let schema = SchemaBuilder::new()
+        .settings(schema_settings)
+        .insert_object_array(
+            "commits",
+            Some("list of commits"),
+            true,
+            schema,
+        )
+        .build();
 
     Ok(schema)
 }

--- a/src/schema/reword.rs
+++ b/src/schema/reword.rs
@@ -1,39 +1,72 @@
 use serde::Deserialize;
 use serde_json::Value;
+use strum::VariantNames;
 
-use crate::schema::{SchemaBuilder, SchemaSettings};
+use crate::{
+    schema::{
+        SchemaBuilder, SchemaSettings,
+        commit::{CommitSchema, PrefixType},
+    },
+    settings::Settings,
+};
 
 /// wrapper struct for the reword response
 /// schema to deserialize from
 #[derive(Debug, Deserialize)]
 pub struct RewordResponse {
     #[serde(default)]
-    pub commit_messages: Vec<CommitMsgSchema>,
+    pub commit_messages: Vec<CommitSchema>,
 }
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct CommitMsgSchema {}
 
 /// creates a schema for new commit messages
 /// following the proper format
-pub fn create_find_schema(
+/// somewhat mimics create commit schema
+/// with tweaks removing the staging portion
+pub fn create_reword_schema(
     schema_settings: SchemaSettings,
-    max: u32,
+    settings: &Settings,
 ) -> anyhow::Result<Value> {
-    let builder = SchemaBuilder::new()
+    let mut builder = SchemaBuilder::new()
         .settings(schema_settings.to_owned())
         .insert_str(
             "reasoning",
             Some("reason why you decided to chose this specific commit"),
             true,
-        )
-        .insert_int(
-            "commit_id",
-            Some("commit index for the chosen commit"),
-            true,
-            Some(0),
-            Some(max),
         );
+
+    builder.add_enum(
+        "prefix",
+        Some("conventional commit type"),
+        true,
+        PrefixType::VARIANTS,
+    );
+
+    if settings
+        .commit
+        .include_scope
+    {
+        builder.add_str("scope", Some("scope of the change"), true);
+    }
+
+    if settings
+        .commit
+        .include_breaking
+    {
+        builder.add_bool(
+            "breaking",
+            Some("is this a breaking change?"),
+            true,
+        );
+    }
+
+    builder.add_str("header", Some("short commit description"), true);
+
+    if settings
+        .rules
+        .allow_body
+    {
+        builder.add_str("body", Some("extended description"), true);
+    }
 
     let schema = builder.build();
 


### PR DESCRIPTION
This PR implements a sort of subset of rebase: reword. It's a bit different but uses the same sort of logic, it doesn't create a plan or regenerate commits, it simply rewords a commit message. It uses the same flags of a rebase:

- last - last _n_ number of commits to reword
- range (`--from`, `--to`) - a specific range of commits, specified by the commit hashes
- commit - a single commit to reword

Note: there's an interactive flow that immediately crashes because it's currently wrapped in a `todo()`. This is intentional, since I wanted to rewrite the entire `print` module, back to `crossterm` and add a bunch of interactivity.